### PR TITLE
Add display:block to anchors around sample images

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -89,6 +89,10 @@ body {
   padding: 10px min(60px,5%);
 }
 
+.content a[href^="samples/"] {
+  display: block;
+}
+
 @media screen and (max-width: 639px) {
   .sidenav {
     width: auto;


### PR DESCRIPTION
The .content div has a max-width of 800px, which makes it possible for sample images that are narrow enough to be shown side-by-side.
This is the case in the last two sample images of the Latin Modern Mono.
This commit makes those anchors display as block elements, so they'll always stack vertically.